### PR TITLE
Add New log messages 

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Logging.cpp
@@ -1,5 +1,6 @@
 #include "AP_NavEKF2.h"
 #include "AP_NavEKF2_core.h"
+#include <GCS_MAVLink/GCS.h>
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_DAL/AP_DAL.h>
@@ -76,8 +77,106 @@ void NavEKF2_core::Log_Write_NKF2(uint64_t time_us) const
         magZ    : (int16_t)(magXYZ.z),
         index   : magSelectIndex
     };
+    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Inside The logging function NKF2");
+
     AP::logger().WriteBlock(&pkt2, sizeof(pkt2));
 }
+
+void NavEKF2_core::Log_Write_CovarianceMatrix(uint64_t time_us) const
+{
+    AP::logger().Write("COV0", "TimeUS,P0,P1,P2,P3,P4,P5,P6,P7,P8,P9,P10,P11", "Qffffffffffff",
+                                        time_us,
+                                        double(P[0][0]),
+                                        double(P[1][1]),
+                                        double(P[2][2]),
+                                        double(P[3][3]),
+                                        double(P[4][4]),
+                                        double(P[5][5]),
+                                        double(P[6][6]),
+                                        double(P[7][7]),
+                                        double(P[8][8]),
+                                        double(P[9][9]),
+                                        double(P[10][10]),
+                                        double(P[11][11])
+                                        );
+
+    AP::logger().Write("COV1", "TimeUS,P12,P13,P14,P15,P16,P17,P18,P19,P20,P21,P22,P23", "Qffffffffffff",
+                                        time_us,
+                                        double(P[12][12]),
+                                        double(P[13][13]),
+                                        double(P[14][14]),
+                                        double(P[15][15]),
+                                        double(P[16][16]),
+                                        double(P[17][17]),
+                                        double(P[18][18]),
+                                        double(P[19][19]),
+                                        double(P[20][20]),
+                                        double(P[21][21]),
+                                        double(P[22][22]),
+                                        double(P[23][23])    
+                                        );
+
+
+}
+
+void NavEKF2_core::Log_Write_FilterFaultStatusFlags(uint64_t time_us) const
+{
+    AP::logger().Write("FFSF", "TUS,xm,ym,zm,aspd,Beta,nv,ev,dv,np,ep,dp,yaw,decl,xf,yf", "QBBBBBBBBBBBBBBB",
+                                        time_us,
+                                        uint8_t(faultStatus.bad_xmag),
+                                        uint8_t(faultStatus.bad_ymag),
+                                        uint8_t(faultStatus.bad_zmag),
+                                        uint8_t(faultStatus.bad_airspeed),
+                                        uint8_t(faultStatus.bad_sideslip),
+                                        uint8_t(faultStatus.bad_nvel),
+                                        uint8_t(faultStatus.bad_evel),
+                                        uint8_t(faultStatus.bad_dvel),
+                                        uint8_t(faultStatus.bad_npos),
+                                        uint8_t(faultStatus.bad_epos),
+                                        uint8_t(faultStatus.bad_dpos),
+                                        uint8_t(faultStatus.bad_yaw),
+                                        uint8_t(faultStatus.bad_decl),
+                                        uint8_t(faultStatus.bad_xflow),
+                                        uint8_t(faultStatus.bad_yflow)
+                                        );
+
+
+}
+
+
+void NavEKF2_core::Log_Write_NavFilterStatusFlags(uint64_t time_us) const
+{
+    AP::logger().Write("NFS0", "TUS,att,hv,vv,hpos_r,hpos_a,v_pos,alt,pos_mod,p_hpos_r,p_hpos_a", "QBBBBBBBBBB",
+                                        time_us,
+                                        uint8_t(filterStatus.flags.attitude),
+                                        uint8_t(filterStatus.flags.horiz_vel),
+                                        uint8_t(filterStatus.flags.vert_vel),
+                                        uint8_t(filterStatus.flags.horiz_pos_rel),
+                                        uint8_t(filterStatus.flags.horiz_pos_abs),
+                                        uint8_t(filterStatus.flags.vert_pos),
+                                        uint8_t(filterStatus.flags.terrain_alt),
+                                        uint8_t(filterStatus.flags.const_pos_mode),
+                                        uint8_t(filterStatus.flags.pred_horiz_pos_rel),
+                                        uint8_t(filterStatus.flags.pred_horiz_pos_abs)
+                                        );
+GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Inside The logging function NKF2");
+
+AP::logger().Write("NFS1", "TUS,tk_d,tk,tdwn,gps,gps_g,gps_gd,init,r_aspd,dead_reckon", "QBBBBBBBBB",
+                                        time_us,
+                                        uint8_t(filterStatus.flags.takeoff_detected),
+                                        uint8_t(filterStatus.flags.takeoff),
+                                        uint8_t(filterStatus.flags.touchdown),
+                                        uint8_t(filterStatus.flags.using_gps),
+                                        uint8_t(filterStatus.flags.gps_glitching),
+                                        uint8_t(filterStatus.flags.gps_quality_good),
+                                        uint8_t(filterStatus.flags.initalized),
+                                        uint8_t(filterStatus.flags.rejecting_airspeed),
+                                        uint8_t(filterStatus.flags.dead_reckoning)
+                                        );
+
+
+}
+
 
 void NavEKF2_core::Log_Write_NKF3(uint64_t time_us) const
 {
@@ -312,7 +411,9 @@ void NavEKF2_core::Log_Write(uint64_t time_us)
     Log_Write_NKF3(time_us);
     Log_Write_NKF4(time_us);
     Log_Write_NKF5(time_us);
-
+    Log_Write_CovarianceMatrix(time_us);
+    Log_Write_FilterFaultStatusFlags(time_us);
+    Log_Write_NavFilterStatusFlags(time_us);
     Log_Write_Quaternion(time_us);
     Log_Write_GSF(time_us);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -165,11 +165,13 @@ public:
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
     bool getLLH(Location &loc) const;
+    bool getLLH(struct Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
     bool getOriginLLH(Location &loc) const;
+    bool getOriginLLH(struct Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -862,6 +864,7 @@ private:
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     Location EKF_origin;     // LLH origin of the NED axis system
+    struct Location EKF_origin;     // LLH origin of the NED axis system
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
     ftype gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
@@ -949,6 +952,7 @@ private:
 
     // variables used by the pre-initialisation GPS checks
     Location gpsloc_prev;    // LLH location of previous GPS measurement
+    struct Location gpsloc_prev;    // LLH location of previous GPS measurement
     uint32_t lastPreAlignGpsCheckTime_ms;   // last time in msec the GPS quality was checked during pre alignment checks
     ftype gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     ftype gpsVertVelFilt;           // amount of filterred vertical GPS velocity detected durng pre-flight GPS checks
@@ -996,11 +1000,6 @@ private:
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.
     bool gpsDataToFuse;             // true when valid GPS data has arrived at the fusion time horizon.
     bool magDataToFuse;             // true when valid magnetometer data has arrived at the fusion time horizon
-    enum AidingMode {
-        AID_ABSOLUTE=0,    // GPS or some other form of absolute position reference aiding is being used (optical flow may also be used in parallel) so position estimates are absolute.
-        AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
-        AID_RELATIVE=2,    // only optical flow aiding is being used so position estimates will be relative
-    };
     AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
     AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions
     bool gndOffsetValid;            // true when the ground offset state can still be considered valid
@@ -1205,4 +1204,7 @@ private:
     void Log_Write_Beacon(uint64_t time_us);
     void Log_Write_Timing(uint64_t time_us);
     void Log_Write_GSF(uint64_t time_us) const;
+    void Log_Write_CovarianceMatrix(uint64_t time_us) const;
+    void Log_Write_FilterFaultStatusFlags(uint64_t time_us) const;
+    void Log_Write_NavFilterStatusFlags(uint64_t time_us) const;
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -164,13 +164,11 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(Location &loc) const;
     bool getLLH(struct Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(Location &loc) const;
     bool getOriginLLH(struct Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
@@ -240,7 +238,6 @@ public:
      7 = filter is not initialised
     */
     void  getFilterFaults(uint16_t &faults) const;
-
     /*
     return filter gps quality check status
     */
@@ -863,7 +860,6 @@ private:
     bool needMagBodyVarReset;       // we need to reset mag body variances at next CovariancePrediction
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
-    Location EKF_origin;     // LLH origin of the NED axis system
     struct Location EKF_origin;     // LLH origin of the NED axis system
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
@@ -951,7 +947,6 @@ private:
     } vertCompFiltState;
 
     // variables used by the pre-initialisation GPS checks
-    Location gpsloc_prev;    // LLH location of previous GPS measurement
     struct Location gpsloc_prev;    // LLH location of previous GPS measurement
     uint32_t lastPreAlignGpsCheckTime_ms;   // last time in msec the GPS quality was checked during pre alignment checks
     ftype gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
@@ -1000,6 +995,10 @@ private:
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.
     bool gpsDataToFuse;             // true when valid GPS data has arrived at the fusion time horizon.
     bool magDataToFuse;             // true when valid magnetometer data has arrived at the fusion time horizon
+    enum AidingMode {AID_ABSOLUTE=0,    // GPS or some other form of absolute position reference aiding is being used (optical flow may also be used in parallel) so position estimates are absolute.
+                     AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
+                     AID_RELATIVE=2    // only optical flow aiding is being used so position estimates will be relative
+                    };
     AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
     AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions
     bool gndOffsetValid;            // true when the ground offset state can still be considered valid

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -164,12 +164,12 @@ public:
     // If a calculated location isn't available, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
-    bool getLLH(struct Location &loc) const;
+    bool getLLH(Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter are relative to this location
     // Returns false if the origin has not been set
-    bool getOriginLLH(struct Location &loc) const;
+    bool getOriginLLH(Location &loc) const;
 
     // set the latitude and longitude and height used to set the NED origin
     // All NED positions calculated by the filter will be relative to this location
@@ -860,7 +860,7 @@ private:
     bool needMagBodyVarReset;       // we need to reset mag body variances at next CovariancePrediction
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
-    struct Location EKF_origin;     // LLH origin of the NED axis system
+    Location EKF_origin;     // LLH origin of the NED axis system
     bool validOrigin;               // true when the EKF origin is valid
     ftype gpsSpdAccuracy;           // estimated speed accuracy in m/s returned by the GPS receiver
     ftype gpsPosAccuracy;           // estimated position accuracy in m returned by the GPS receiver
@@ -947,7 +947,7 @@ private:
     } vertCompFiltState;
 
     // variables used by the pre-initialisation GPS checks
-    struct Location gpsloc_prev;    // LLH location of previous GPS measurement
+    Location gpsloc_prev;    // LLH location of previous GPS measurement
     uint32_t lastPreAlignGpsCheckTime_ms;   // last time in msec the GPS quality was checked during pre alignment checks
     ftype gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     ftype gpsVertVelFilt;           // amount of filterred vertical GPS velocity detected durng pre-flight GPS checks
@@ -995,9 +995,10 @@ private:
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.
     bool gpsDataToFuse;             // true when valid GPS data has arrived at the fusion time horizon.
     bool magDataToFuse;             // true when valid magnetometer data has arrived at the fusion time horizon
-    enum AidingMode {AID_ABSOLUTE=0,    // GPS or some other form of absolute position reference aiding is being used (optical flow may also be used in parallel) so position estimates are absolute.
-                     AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
-                     AID_RELATIVE=2    // only optical flow aiding is being used so position estimates will be relative
+    enum AidingMode {
+    	AID_ABSOLUTE=0,    // GPS or some other form of absolute position reference aiding is being used (optical flow may also be used in parallel) so position estimates are absolute.
+        AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
+        AID_RELATIVE=2    // only optical flow aiding is being used so position estimates will be relative
                     };
     AidingMode PV_AidingMode;       // Defines the preferred mode for aiding of velocity and position estimates from the INS
     AidingMode PV_AidingModePrev;   // Value of PV_AidingMode from the previous frame - used to detect transitions


### PR DESCRIPTION
Added 3 new log messages in EKF for Covariance matrix, filter fault status flags and nav filter status flags. 

Message names are: 
- **COV0** : Diagonal covariance matrix entries P0-P11. 
- **COV1** : Diagonal covariance matrix entries P12-P23. 
- **FFSF** : Filter Fault Status Flags.
- **NFS0** and **NFS1** : Nav Filter Status Flags.